### PR TITLE
Add missing header for std::function and std::bind

### DIFF
--- a/src/pingus/screens/demo_session.cpp
+++ b/src/pingus/screens/demo_session.cpp
@@ -18,6 +18,7 @@
 
 #include <algorithm>
 #include <iostream>
+#include <functional>
 
 #include "engine/gui/gui_manager.hpp"
 #include "engine/gui/surface_button.hpp"


### PR DESCRIPTION
This causes a build failure with GCC 7, because `<functional>` is no longer included indirectly by other headers. The code should include the right headers for the features it uses.